### PR TITLE
DIS 435 - Fix bug booking description does not show correctly in planning

### DIFF
--- a/sale/classes/booking/Booking.class.php
+++ b/sale/classes/booking/Booking.class.php
@@ -53,7 +53,7 @@ class Booking extends Model {
 
             'description' => [
                 'type'              => 'string',
-                'usage'             => 'text/plain',
+                'usage'             => 'text/html',
                 'description'       => "Reason or comments about the booking, if any (for internal use).",
                 'default'           => ''
             ],


### PR DESCRIPTION
modification of the Booking's description usage to resolve bug when display planning description